### PR TITLE
Quita el guión bajo del nombre del paquete

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,4 +1,4 @@
-Package: pavement_management
+Package: pavementmanagement
 Type: Package
 Title: Pavement Management
 Version: 0.0.1

--- a/man/clasifica_vehiculos.Rd
+++ b/man/clasifica_vehiculos.Rd
@@ -2,7 +2,7 @@
 \alias{clasifica_vehiculos}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{
-%%  ~~function to do ... ~~
+Clasifica Vehículos
 }
 \description{
 %%  ~~ A concise (1-5 lines) description of what the function does. ~~

--- a/man/concatena_archivos.Rd
+++ b/man/concatena_archivos.Rd
@@ -2,7 +2,7 @@
 \alias{concatena_archivos}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{
-%%  ~~function to do ... ~~
+Concatena Archivos
 }
 \description{
 %%  ~~ A concise (1-5 lines) description of what the function does. ~~

--- a/man/convierte_a_kg.Rd
+++ b/man/convierte_a_kg.Rd
@@ -2,7 +2,7 @@
 \alias{convierte_a_kg}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{
-%%  ~~function to do ... ~~
+Convierte a kg
 }
 \description{
 %%  ~~ A concise (1-5 lines) description of what the function does. ~~

--- a/man/convierte_a_metros.Rd
+++ b/man/convierte_a_metros.Rd
@@ -2,7 +2,7 @@
 \alias{convierte_a_metros}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{
-%%  ~~function to do ... ~~
+Convierte a metros
 }
 \description{
 %%  ~~ A concise (1-5 lines) description of what the function does. ~~

--- a/man/convierte_a_toneladas.Rd
+++ b/man/convierte_a_toneladas.Rd
@@ -2,7 +2,7 @@
 \alias{convierte_a_toneladas}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{
-%%  ~~function to do ... ~~
+Convierte a toneladas
 }
 \description{
 %%  ~~ A concise (1-5 lines) description of what the function does. ~~

--- a/man/cuenta_ejes.Rd
+++ b/man/cuenta_ejes.Rd
@@ -2,7 +2,7 @@
 \alias{cuenta_ejes}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{
-%%  ~~function to do ... ~~
+Cuenta ejes
 }
 \description{
 %%  ~~ A concise (1-5 lines) description of what the function does. ~~

--- a/man/genera_espectros.Rd
+++ b/man/genera_espectros.Rd
@@ -2,7 +2,7 @@
 \alias{genera_espectros}
 %- Also NEED an '\alias' for EACH other topic documented here.
 \title{
-%%  ~~function to do ... ~~
+Genera espectros
 }
 \description{
 %%  ~~ A concise (1-5 lines) description of what the function does. ~~


### PR DESCRIPTION
Porque causa un error al momento de instalarlo